### PR TITLE
Explicitly telling iframe container to scroll horizontally

### DIFF
--- a/src/scss/_single.scss
+++ b/src/scss/_single.scss
@@ -120,7 +120,7 @@
 			}
 		}
 		.iframe-container {
-			overflow: auto;
+			overflow-x: scroll;
 			-webkit-overflow-scrolling: touch;
 		}
 		iframe {


### PR DESCRIPTION
@danmihaila Can you please deploy this fix? This will hopefully fix the mobile Safari iframe scrolling issue finally. Thank you!